### PR TITLE
Add Create: Fluid centrifugal pump compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 *.iws
 out/
 
+# VS Code
+.vscode/
+
 # Kotlin
 .kotlin/
 
@@ -44,3 +47,7 @@ Thumbs.db
 # Claude Code
 .claude/
 CLAUDE.md
+
+# Local temp / decompile scratch
+tmp/
+tmp*

--- a/src/main/java/de/devin/pipesnphysics/PipesNPhysics.java
+++ b/src/main/java/de/devin/pipesnphysics/PipesNPhysics.java
@@ -4,6 +4,7 @@ import com.simibubi.create.foundation.data.CreateRegistrate;
 import com.simibubi.create.foundation.item.ItemDescription;
 import com.simibubi.create.foundation.item.KineticStats;
 import com.simibubi.create.foundation.item.TooltipModifier;
+import de.devin.pipesnphysics.compat.CreateFluidCompat;
 import de.devin.pipesnphysics.compat.SableCompat;
 import de.devin.pipesnphysics.engine.EngineTickHandler;
 import de.devin.pipesnphysics.engine.OpenEndPipes;
@@ -68,6 +69,9 @@ public class PipesNPhysics {
     }
 
     private void onCommonSetup(FMLCommonSetupEvent event) {
+        if (CreateFluidCompat.isLoaded()) {
+            LOGGER.info("Create: Fluid compatibility enabled");
+        }
         LOGGER.info("Common setup...");
     }
 }

--- a/src/main/java/de/devin/pipesnphysics/client/PumpRangeRenderer.java
+++ b/src/main/java/de/devin/pipesnphysics/client/PumpRangeRenderer.java
@@ -6,6 +6,7 @@ import com.mojang.blaze3d.vertex.VertexConsumer;
 import com.mojang.math.Axis;
 import com.simibubi.create.content.equipment.goggles.GogglesItem;
 import com.simibubi.create.content.fluids.pump.PumpBlock;
+import de.devin.pipesnphysics.compat.CreateFluidCompat;
 import de.devin.pipesnphysics.PipesNPhysics;
 import de.devin.pipesnphysics.PipesNPhysicsConfig;
 import de.devin.pipesnphysics.engine.net.PumpRangePayload;
@@ -17,6 +18,7 @@ import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
@@ -63,7 +65,7 @@ public final class PumpRangeRenderer {
         long now = mc.level.getGameTime();
         if (mc.hitResult instanceof BlockHitResult blockHit
                 && mc.hitResult.getType() == HitResult.Type.BLOCK
-                && mc.level.getBlockState(blockHit.getBlockPos()).getBlock() instanceof PumpBlock) {
+                && isPumpBlock(mc.level.getBlockState(blockHit.getBlockPos()))) {
             PumpRangeClient.looking(blockHit.getBlockPos(), now);
         }
 
@@ -142,6 +144,10 @@ public final class PumpRangeRenderer {
                     FULL_BRIGHTNESS, OverlayTexture.NO_OVERLAY);
         }
         poseStack.popPose();
+    }
+
+    private static boolean isPumpBlock(BlockState state) {
+        return state.getBlock() instanceof PumpBlock || CreateFluidCompat.isCentrifugalPump(state);
     }
 
     private static void applyDirectionRotation(PoseStack poseStack, Direction dir) {

--- a/src/main/java/de/devin/pipesnphysics/compat/CreateFluidCompat.java
+++ b/src/main/java/de/devin/pipesnphysics/compat/CreateFluidCompat.java
@@ -1,0 +1,119 @@
+package de.devin.pipesnphysics.compat;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+
+/**
+ * Optional compatibility with Create: Fluid's centrifugal pump ({@code fluid:centrifugal_pump}).
+ * Uses reflection so the mod is not a hard dependency.
+ */
+public final class CreateFluidCompat {
+    public static final ResourceLocation CENTRIFUGAL_PUMP_ID =
+            ResourceLocation.fromNamespaceAndPath("fluid", "centrifugal_pump");
+
+    /** Create: Fluid applies 2× pressure vs Create's mechanical pump at the same RPM. */
+    public static final double PERFORMANCE_MULTIPLIER = 2.0;
+
+    private static final Provider PROVIDER;
+
+    static {
+        Provider provider;
+        try {
+            Class.forName("com.adonis.fluid.block.CentrifugalPump.CentrifugalPumpBlock", false,
+                    CreateFluidCompat.class.getClassLoader());
+            provider = new ReflectiveProvider();
+        } catch (ReflectiveOperationException | LinkageError e) {
+            provider = NoOpProvider.INSTANCE;
+        }
+        PROVIDER = provider;
+    }
+
+    private CreateFluidCompat() {}
+
+    public static boolean isLoaded() {
+        return PROVIDER instanceof ReflectiveProvider;
+    }
+
+    public static boolean isCentrifugalPump(BlockState state) {
+        return PROVIDER.isCentrifugalPump(state);
+    }
+
+    public static boolean isCentrifugalPump(Level level, BlockPos pos) {
+        return PROVIDER.isCentrifugalPump(level.getBlockState(pos));
+    }
+
+    /** Push and pull ports; null when the block is not a centrifugal pump or ports cannot resolve. */
+    public static PumpPorts getPumpPorts(Level level, BlockPos pos, BlockState state) {
+        return PROVIDER.getPumpPorts(level, pos, state);
+    }
+
+    public static Direction getPushSide(Level level, BlockPos pos, BlockState state) {
+        PumpPorts ports = getPumpPorts(level, pos, state);
+        return ports != null ? ports.push() : null;
+    }
+
+    public record PumpPorts(Direction push, Direction pull) {}
+
+    private interface Provider {
+        boolean isCentrifugalPump(BlockState state);
+
+        PumpPorts getPumpPorts(Level level, BlockPos pos, BlockState state);
+    }
+
+    private static final class NoOpProvider implements Provider {
+        static final NoOpProvider INSTANCE = new NoOpProvider();
+
+        @Override
+        public boolean isCentrifugalPump(BlockState state) {
+            return false;
+        }
+
+        @Override
+        public PumpPorts getPumpPorts(Level level, BlockPos pos, BlockState state) {
+            return null;
+        }
+    }
+
+    private static final class ReflectiveProvider implements Provider {
+        private final Class<?> blockClass;
+        private final Class<?> beClass;
+
+        ReflectiveProvider() throws ReflectiveOperationException {
+            blockClass = Class.forName("com.adonis.fluid.block.CentrifugalPump.CentrifugalPumpBlock");
+            beClass = Class.forName("com.adonis.fluid.block.CentrifugalPump.CentrifugalPumpBlockEntity");
+        }
+
+        @Override
+        public boolean isCentrifugalPump(BlockState state) {
+            return blockClass.isInstance(state.getBlock());
+        }
+
+        @Override
+        public PumpPorts getPumpPorts(Level level, BlockPos pos, BlockState state) {
+            if (!isCentrifugalPump(state)) return null;
+            try {
+                Direction primary = (Direction) blockClass
+                        .getMethod("getPrimaryFluidDirection", BlockState.class)
+                        .invoke(null, state);
+                Direction secondary = (Direction) blockClass
+                        .getMethod("getSecondaryFluidDirection", BlockState.class)
+                        .invoke(null, state);
+                if (primary == null || secondary == null) return null;
+
+                var be = level.getBlockEntity(pos);
+                if (!beClass.isInstance(be)) return null;
+                boolean pullPrimary = (boolean) beClass
+                        .getMethod("isPullingOnSide", boolean.class)
+                        .invoke(be, true);
+                Direction push = pullPrimary ? secondary : primary;
+                Direction pull = pullPrimary ? primary : secondary;
+                return new PumpPorts(push, pull);
+            } catch (ReflectiveOperationException e) {
+                return null;
+            }
+        }
+    }
+}

--- a/src/main/java/de/devin/pipesnphysics/engine/FlowSolver.java
+++ b/src/main/java/de/devin/pipesnphysics/engine/FlowSolver.java
@@ -3,6 +3,7 @@ package de.devin.pipesnphysics.engine;
 import com.simibubi.create.content.fluids.FluidPropagator;
 import com.simibubi.create.content.kinetics.base.KineticBlockEntity;
 import de.devin.pipesnphysics.PipesNPhysicsConfig;
+import de.devin.pipesnphysics.compat.CreateFluidCompat;
 import de.devin.pipesnphysics.compat.SableCompat;
 import de.devin.pipesnphysics.engine.solve.Apportion;
 import de.devin.pipesnphysics.engine.solve.NetworkSolver;
@@ -255,7 +256,9 @@ public final class FlowSolver {
         for (Node pump : graph.pumps()) {
             float speed = level.getBlockEntity(pump.pos()) instanceof KineticBlockEntity kinetic
                     ? kinetic.getSpeed() : 0;
-            double head = Math.abs(speed) * headPerRpm;
+            double mult = CreateFluidCompat.isCentrifugalPump(level, pump.pos())
+                    ? CreateFluidCompat.PERFORMANCE_MULTIPLIER : 1.0;
+            double head = Math.abs(speed) * headPerRpm * mult;
             pumps.put(pump.index(), new PumpState(isPumpRunning(level, pump), head, pump.pumpFacing(),
                     flowPerRpm / headPerRpm));
         }
@@ -693,7 +696,7 @@ public final class FlowSolver {
                 driveNode = driveNode < 0 ? nodeIndex : -2;
                 driveHead = pump.head();
                 driveInternalG = pump.internalConductance();
-            } else if (toward.equals(pumpNode.pos().relative(pump.pushSide().getOpposite()))) {
+            } else if (toward.equals(pumpNode.pos().relative(pumpNode.effectivePullSide()))) {
                 allowedSign = combineSign(allowedSign, -outSign);
             } else {
                 blockedEdges.add(edge.index());

--- a/src/main/java/de/devin/pipesnphysics/engine/GraphBuilder.java
+++ b/src/main/java/de/devin/pipesnphysics/engine/GraphBuilder.java
@@ -5,8 +5,9 @@ import com.simibubi.create.content.fluids.FluidTransportBehaviour;
 import com.simibubi.create.content.fluids.pipes.VanillaFluidTargets;
 import com.simibubi.create.content.fluids.pump.PumpBlock;
 import com.simibubi.create.content.fluids.tank.FluidTankBlockEntity;
-import de.devin.pipesnphysics.mixin.FluidTankAccessor;
+import de.devin.pipesnphysics.compat.CreateFluidCompat;
 import de.devin.pipesnphysics.compat.SableCompat;
+import de.devin.pipesnphysics.mixin.FluidTankAccessor;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.Level;
@@ -104,6 +105,12 @@ public final class GraphBuilder {
                 BlockState bs = level.getBlockState(pos);
                 if (bs.getBlock() instanceof PumpBlock) {
                     facing = bs.getValue(PumpBlock.FACING);
+                } else if (CreateFluidCompat.isCentrifugalPump(bs)) {
+                    CreateFluidCompat.PumpPorts ports = CreateFluidCompat.getPumpPorts(level, pos, bs);
+                    if (ports != null) {
+                        facing = ports.push();
+                        accessFace = ports.pull();
+                    }
                 }
             } else if (d.handlers.contains(pos)) {
                 kind = Node.Kind.HANDLER;
@@ -177,7 +184,9 @@ public final class GraphBuilder {
 
     private static boolean isPipeLike(Level level, BlockPos pos) {
         if (!level.isLoaded(pos)) return false;
-        return FluidPropagator.getPipe(level, pos) != null || isConduit(level, pos);
+        BlockState state = level.getBlockState(pos);
+        return FluidPropagator.getPipe(level, pos) != null || isConduit(level, pos)
+                || isPumpBlock(state);
     }
 
     /** BFS state. */
@@ -203,12 +212,14 @@ public final class GraphBuilder {
 
             FluidTransportBehaviour pipe = FluidPropagator.getPipe(level, cur);
             if (pipe == null) {
-                if (isConduit(level, cur)) discoverConduit(level, cur, d, frontier);
+                BlockState curState = level.getBlockState(cur);
+                if (isPumpBlock(curState)) discoverPump(level, cur, d, frontier);
+                else if (isConduit(level, cur)) discoverConduit(level, cur, d, frontier);
                 continue;
             }
 
             BlockState curState = level.getBlockState(cur);
-            boolean isPump = curState.getBlock() instanceof PumpBlock;
+            boolean isPump = isPumpBlock(curState);
             if (isPump) d.pumps.add(cur);
             else d.pipes.add(cur);
 
@@ -218,7 +229,8 @@ public final class GraphBuilder {
                 if (!level.isLoaded(neighbor)) continue;
                 BlockState nState = level.getBlockState(neighbor);
 
-                if (nState.getBlock() instanceof PumpBlock) {
+                if (isPumpBlock(nState)) {
+                    if (!isPumpPortFace(level, neighbor, nState, face.getOpposite())) continue;
                     d.pumps.add(neighbor.immutable());
                     conns.add(neighbor.immutable());
                     frontier.add(neighbor.immutable());
@@ -364,7 +376,9 @@ public final class GraphBuilder {
             BlockPos neighbor = cur.relative(face);
             if (!level.isLoaded(neighbor)) continue;
 
-            if (level.getBlockState(neighbor).getBlock() instanceof PumpBlock) {
+            BlockState nState = level.getBlockState(neighbor);
+            if (isPumpBlock(nState)) {
+                if (!isPumpPortFace(level, neighbor, nState, face.getOpposite())) continue;
                 d.pumps.add(neighbor.immutable());
                 conns.add(neighbor.immutable());
                 frontier.add(neighbor.immutable());
@@ -383,6 +397,75 @@ public final class GraphBuilder {
             }
         }
         d.connections.put(cur, conns);
+    }
+
+    /**
+     * Explore a pump that has no Create {@link FluidTransportBehaviour} (e.g. Create: Fluid's
+     * centrifugal pump). Without this, the pump can be queued from an adjacent pipe but is
+     * dropped on visit before its other port is scanned.
+     */
+    private static void discoverPump(Level level, BlockPos cur, Discovery d, Queue<BlockPos> frontier) {
+        d.pumps.add(cur);
+        BlockState curState = level.getBlockState(cur);
+        List<BlockPos> conns = new ArrayList<>();
+        for (Direction face : pumpPortFaces(level, cur, curState)) {
+            BlockPos neighbor = cur.relative(face);
+            if (!level.isLoaded(neighbor)) continue;
+            BlockState nState = level.getBlockState(neighbor);
+
+            if (isPumpBlock(nState)) {
+                if (!isPumpPortFace(level, neighbor, nState, face.getOpposite())) continue;
+                d.pumps.add(neighbor.immutable());
+                conns.add(neighbor.immutable());
+                frontier.add(neighbor.immutable());
+                continue;
+            }
+
+            var handler = level.getCapability(
+                    Capabilities.FluidHandler.BLOCK, neighbor, face.getOpposite());
+            if (handler != null && !VanillaFluidTargets.canProvideFluidWithoutCapability(nState)
+                    && !HandlerRoles.isIgnored(level, neighbor)) {
+                d.handlers.add(neighbor.immutable());
+                conns.add(neighbor.immutable());
+                if (isConduit(level, neighbor)) frontier.add(neighbor.immutable());
+                continue;
+            }
+
+            var neighborPipe = FluidPropagator.getPipe(level, neighbor);
+            if (neighborPipe != null) {
+                if (neighborPipe.canHaveFlowToward(nState, face.getOpposite())) {
+                    conns.add(neighbor.immutable());
+                    frontier.add(neighbor.immutable());
+                }
+                continue;
+            }
+
+            if (FluidPropagator.isOpenEnd(level, cur, face)) {
+                d.openEnds.putIfAbsent(neighbor.immutable(), face.getOpposite());
+                conns.add(neighbor.immutable());
+            }
+        }
+        d.connections.put(cur, conns);
+    }
+
+    private static boolean isPumpBlock(BlockState state) {
+        return state.getBlock() instanceof PumpBlock || CreateFluidCompat.isCentrifugalPump(state);
+    }
+
+    private static List<Direction> pumpPortFaces(Level level, BlockPos pos, BlockState state) {
+        if (state.getBlock() instanceof PumpBlock) {
+            Direction facing = state.getValue(PumpBlock.FACING);
+            return List.of(facing, facing.getOpposite());
+        }
+        if (CreateFluidCompat.isCentrifugalPump(state)) {
+            CreateFluidCompat.PumpPorts ports = CreateFluidCompat.getPumpPorts(level, pos, state);
+            if (ports != null) return List.of(ports.push(), ports.pull());
+        }
+        return List.of();
+    }
+
+    private static boolean isPumpPortFace(Level level, BlockPos pos, BlockState state, Direction face) {
+        return pumpPortFaces(level, pos, state).contains(face);
     }
 
     /**

--- a/src/main/java/de/devin/pipesnphysics/engine/Node.java
+++ b/src/main/java/de/devin/pipesnphysics/engine/Node.java
@@ -23,8 +23,9 @@ import net.minecraft.core.Direction;
  *
  * {@code accessFace} is the face a HANDLER is reached through when it is SIDE-SPECIFIC (exposes no
  * side-agnostic {@code null} capability): the network resolves and transfers the handler through that
- * exact face, so a block with a different tank per side serves each side its own fluid. It is null for
- * an ordinary side-agnostic handler (resolved through {@code null}) and for every non-handler node.
+ * exact face, so a block with a different tank per side serves each side its own fluid. For pumps whose
+ * suction port is not opposite push (e.g. Create: Fluid's centrifugal pump), it stores the pull face.
+ * It is null for an ordinary side-agnostic handler and for pumps with inline push/pull.
  */
 public record Node(int index, BlockPos pos, Kind kind, double worldY,
                    Direction pumpFacing, Direction openFace, Direction accessFace) {
@@ -35,4 +36,11 @@ public record Node(int index, BlockPos pos, Kind kind, double worldY,
     public boolean isJunction() { return kind == Kind.JUNCTION; }
     public boolean isOpenEnd() { return kind == Kind.OPEN_END; }
     public boolean isClosedGate() { return kind == Kind.CLOSED_GATE; }
+
+    /** Suction port: explicit for orthogonal pumps, otherwise opposite of {@link #pumpFacing}. */
+    public Direction effectivePullSide() {
+        if (!isPump() || pumpFacing == null) return null;
+        if (accessFace != null) return accessFace;
+        return pumpFacing.getOpposite();
+    }
 }

--- a/src/main/java/de/devin/pipesnphysics/engine/PumpRangeProbe.java
+++ b/src/main/java/de/devin/pipesnphysics/engine/PumpRangeProbe.java
@@ -53,7 +53,7 @@ public final class PumpRangeProbe {
         for (Edge edge : graph.edgesOf(pump.index())) {
             BlockPos toward = PipeGeometry.adjacentCell(graph, edge, pump.index());
             boolean push = toward.equals(pumpPos.relative(pump.pumpFacing()));
-            boolean pull = toward.equals(pumpPos.relative(pump.pumpFacing().getOpposite()));
+            boolean pull = toward.equals(pumpPos.relative(pump.effectivePullSide()));
             if (!push && !pull) continue;
 
             List<BlockPos> seed = new ArrayList<>();

--- a/src/main/java/de/devin/pipesnphysics/mixin/CentrifugalPumpBlockEntityMixin.java
+++ b/src/main/java/de/devin/pipesnphysics/mixin/CentrifugalPumpBlockEntityMixin.java
@@ -1,0 +1,63 @@
+package de.devin.pipesnphysics.mixin;
+
+import de.devin.pipesnphysics.PipesNPhysicsConfig;
+import de.devin.pipesnphysics.compat.CreateFluidCompat;
+import de.devin.pipesnphysics.engine.EngineTickHandler;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Suppresses Create: Fluid's pressure distribution while the engine is enabled and
+ * wakes the network when the centrifugal pump's push/pull assignment changes.
+ */
+@Mixin(targets = "com.adonis.fluid.block.CentrifugalPump.CentrifugalPumpBlockEntity", remap = false)
+public abstract class CentrifugalPumpBlockEntityMixin {
+    @Unique
+    private Direction pipesnphysics$lastPush = null;
+
+    @Unique
+    private BlockEntity pipesnphysics$self() {
+        return (BlockEntity) (Object) this;
+    }
+
+    @Inject(method = "tick", at = @At("HEAD"))
+    private void pipesnphysics$detectPortChange(CallbackInfo ci) {
+        BlockEntity self = pipesnphysics$self();
+        Level world = self.getLevel();
+        if (world == null || world.isClientSide()) return;
+        if (!PipesNPhysicsConfig.ENABLE_ENGINE.get()) return;
+        BlockState state = self.getBlockState();
+        if (!CreateFluidCompat.isCentrifugalPump(state)) return;
+
+        BlockPos pos = self.getBlockPos();
+        Direction push = CreateFluidCompat.getPushSide(world, pos, state);
+        if (push == null) return;
+        if (pipesnphysics$lastPush != null && pipesnphysics$lastPush != push) {
+            CreateFluidCompat.PumpPorts ports = CreateFluidCompat.getPumpPorts(world, pos, state);
+            if (ports != null) {
+                EngineTickHandler.markChanged(world, pos.relative(ports.push()));
+                EngineTickHandler.markChanged(world, pos.relative(ports.pull()));
+            }
+        }
+        pipesnphysics$lastPush = push;
+    }
+
+    @Inject(method = "distributePressureTo", at = @At("HEAD"), cancellable = true)
+    private void pipesnphysics$replacePressureDistribution(Direction side, CallbackInfo ci) {
+        if (!PipesNPhysicsConfig.ENABLE_ENGINE.get()) return;
+        BlockEntity self = pipesnphysics$self();
+        Level world = self.getLevel();
+        if (world != null && !world.isClientSide()) {
+            EngineTickHandler.markChanged(world, self.getBlockPos().relative(side));
+        }
+        ci.cancel();
+    }
+}

--- a/src/main/java/de/devin/pipesnphysics/mixin/CreateFluidMixinPlugin.java
+++ b/src/main/java/de/devin/pipesnphysics/mixin/CreateFluidMixinPlugin.java
@@ -1,0 +1,46 @@
+package de.devin.pipesnphysics.mixin;
+
+import net.neoforged.fml.loading.FMLLoader;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+
+/** Applies Create: Fluid mixins only when the mod is installed. */
+public class CreateFluidMixinPlugin implements IMixinConfigPlugin {
+    private static final boolean CREATE_FLUID_PRESENT =
+            FMLLoader.getLoadingModList().getModFileById("fluid") != null;
+
+    @Override
+    public void onLoad(String mixinPackage) {
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        return CREATE_FLUID_PRESENT;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+    }
+
+    @Override
+    public List<String> getMixins() {
+        return null;
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+    }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+    }
+}

--- a/src/main/resources/pipesnphysics.createfluid.mixins.json
+++ b/src/main/resources/pipesnphysics.createfluid.mixins.json
@@ -1,0 +1,14 @@
+{
+  "required": false,
+  "minVersion": "0.8",
+  "package": "de.devin.pipesnphysics.mixin",
+  "compatibilityLevel": "JAVA_21",
+  "refmap": "pipesnphysics.refmap.json",
+  "plugin": "de.devin.pipesnphysics.mixin.CreateFluidMixinPlugin",
+  "mixins": [
+    "CentrifugalPumpBlockEntityMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -15,6 +15,9 @@ config = "${mod_id}.mixins.json"
 [[mixins]]
 config = "${mod_id}.sable.mixins.json"
 
+[[mixins]]
+config = "${mod_id}.createfluid.mixins.json"
+
 [[dependencies.${mod_id}]]
 modId = "neoforge"
 type = "required"
@@ -47,5 +50,12 @@ side = "BOTH"
 modId = "sable"
 type = "optional"
 versionRange = "[1.2.0,)"
+ordering = "AFTER"
+side = "BOTH"
+
+[[dependencies.${mod_id}]]
+modId = "fluid"
+type = "optional"
+versionRange = "[2.0.0,)"
 ordering = "AFTER"
 side = "BOTH"


### PR DESCRIPTION
## Summary
- Optional Create: Fluid compat for centrifugal pumps (reflection-based, no hard dep)
- Rebased on upstream v2.1.1; uses \Node.accessFace\ for orthogonal pump pull ports
- Excludes mixin bootstrap fixes and VS Code setup (separate PR)

## Test plan
- [ ] Connect Create: Fluid centrifugal pump to pipe network with engine enabled
- [ ] Verify push/pull on orthogonal ports
- [ ] Verify pump range arrows work when looking at centrifugal pump with goggles
- [ ] Build without Create: Fluid installed

Made with [Cursor](https://cursor.com)