### PR TITLE
Add create: connectred conpat

### DIFF
--- a/src/main/java/de/devin/pipesnphysics/compat/CreatePipeRendering.java
+++ b/src/main/java/de/devin/pipesnphysics/compat/CreatePipeRendering.java
@@ -8,11 +8,11 @@ import de.devin.pipesnphysics.PipesNPhysicsConfig;
 import de.devin.pipesnphysics.engine.Edge;
 import de.devin.pipesnphysics.engine.EdgeFlow;
 import de.devin.pipesnphysics.engine.Graph;
+import de.devin.pipesnphysics.engine.FluidTankGeometry;
 import de.devin.pipesnphysics.engine.Node;
 import de.devin.pipesnphysics.engine.PipeGeometry;
 import de.devin.pipesnphysics.engine.PipeProbe;
 import de.devin.pipesnphysics.engine.Solution;
-import de.devin.pipesnphysics.mixin.FluidTankAccessor;
 import de.devin.pipesnphysics.mixin.PipeConnectionAccessor;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -123,8 +123,8 @@ public final class CreatePipeRendering {
         if (!(level.getBlockEntity(pos) instanceof FluidTankBlockEntity tank)) return head;
         FluidTankBlockEntity controller = tank.getControllerBE();
         if (controller == null) return head;
-        int height = ((FluidTankAccessor) (Object) controller).pipesnphysics$getHeight();
-        double controllerBottom = SableCompat.getWorldY(level, controller.getBlockPos()) - 0.5;
+        int height = FluidTankGeometry.columnHeightBlocks(controller);
+        double controllerBottom = FluidTankGeometry.columnBaseY(level, controller.getBlockPos(), controller);
         double fill = Math.clamp((head - controllerBottom) / height, 0.0, 1.0);
         return controllerBottom + (TANK_CAP + TANK_PUDDLE) + fill * (height - 2 * TANK_CAP - TANK_PUDDLE);
     }
@@ -1467,11 +1467,11 @@ public final class CreatePipeRendering {
         }
     }
 
-    /** Block height of a reservoir column at {@code pos} (a multiblock tank's controller height), 1 otherwise. */
+    /** Block height of a reservoir column at {@code pos} (a multiblock tank's vertical extent), 1 otherwise. */
     private static int columnHeight(Level level, BlockPos pos) {
         if (level.getBlockEntity(pos) instanceof FluidTankBlockEntity tank) {
             FluidTankBlockEntity controller = tank.getControllerBE();
-            if (controller != null) return ((FluidTankAccessor) (Object) controller).pipesnphysics$getHeight();
+            if (controller != null) return FluidTankGeometry.columnHeightBlocks(controller);
         }
         return 1;
     }

--- a/src/main/java/de/devin/pipesnphysics/compat/SableCompanionImpl.java
+++ b/src/main/java/de/devin/pipesnphysics/compat/SableCompanionImpl.java
@@ -75,14 +75,20 @@ class SableCompanionImpl implements SableCompatProvider {
 
     @Override
     public double getColumnBaseY(Level level, BlockPos pos, int width, int height) {
+        return getColumnBaseYAtCenter(level, pos, width / 2.0, height / 2.0, width / 2.0, height);
+    }
+
+    @Override
+    public double getColumnBaseYAtCenter(Level level, BlockPos pos, double halfX, double halfY, double halfZ,
+                                         int verticalBlocks) {
         // Anchor at the box's projected geometric CENTER, not the bottom corner: on a tilt the
         // corner the controller sits at is not the lowest point, so baseY = getWorldY(controller)-0.5
         // skews the surface and spills a partial tank. The center projects exactly, and the surface
         // is then center + (fillFraction - 0.5)·height·cosTilt — i.e. baseY = center − 0.5·height·cosTilt.
         Vector3d center = SableCompanion.INSTANCE.projectOutOfSubLevel(level,
-                new Vector3d(pos.getX() + width / 2.0, pos.getY() + height / 2.0, pos.getZ() + width / 2.0),
+                new Vector3d(pos.getX() + halfX, pos.getY() + halfY, pos.getZ() + halfZ),
                 new Vector3d());
-        return center.y - 0.5 * height * getUpProjectionY(level, pos);
+        return center.y - 0.5 * verticalBlocks * getUpProjectionY(level, pos);
     }
 
     @Override

--- a/src/main/java/de/devin/pipesnphysics/compat/SableCompat.java
+++ b/src/main/java/de/devin/pipesnphysics/compat/SableCompat.java
@@ -97,6 +97,15 @@ public class SableCompat {
         return PROVIDER.getColumnBaseY(level, pos, width, height);
     }
 
+    /**
+     * Like {@link #getColumnBaseY} but for a tank whose geometric center is not at
+     * {@code (width/2, height/2, width/2)} — horizontal fluid vessels lay out along X/Z.
+     */
+    public static double getColumnBaseYAtCenter(Level level, BlockPos pos, double halfX, double halfY,
+                                                double halfZ, int verticalBlocks) {
+        return PROVIDER.getColumnBaseYAtCenter(level, pos, halfX, halfY, halfZ, verticalBlocks);
+    }
+
     public static float getTiltAngle(Level level, BlockPos pos) {
         return PROVIDER.getTiltAngle(level, pos);
     }
@@ -165,6 +174,12 @@ public class SableCompat {
         @Override
         public double getColumnBaseY(Level level, BlockPos pos, int width, int height) {
             return pos.getY();
+        }
+
+        @Override
+        public double getColumnBaseYAtCenter(Level level, BlockPos pos, double halfX, double halfY,
+                                             double halfZ, int verticalBlocks) {
+            return pos.getY() + halfY - 0.5 * verticalBlocks;
         }
 
         @Override

--- a/src/main/java/de/devin/pipesnphysics/compat/SableCompatProvider.java
+++ b/src/main/java/de/devin/pipesnphysics/compat/SableCompatProvider.java
@@ -16,6 +16,8 @@ interface SableCompatProvider {
     Vec3 getWorldPos(Level level, BlockPos pos);
     double getUpProjectionY(Level level, BlockPos pos);
     double getColumnBaseY(Level level, BlockPos pos, int width, int height);
+    double getColumnBaseYAtCenter(Level level, BlockPos pos, double halfX, double halfY, double halfZ,
+                                  int verticalBlocks);
     float getTiltAngle(Level level, BlockPos pos);
     float getTiltAngleClient(BlockEntity be);
     float getPipeElevation(Level level, BlockPos pos, Direction dir);

--- a/src/main/java/de/devin/pipesnphysics/compat/SablePhysicsCompat.java
+++ b/src/main/java/de/devin/pipesnphysics/compat/SablePhysicsCompat.java
@@ -1,7 +1,9 @@
 package de.devin.pipesnphysics.compat;
 
+import com.simibubi.create.content.fluids.tank.FluidTankBlockEntity;
 import de.devin.pipesnphysics.PipesNPhysics;
 import de.devin.pipesnphysics.PipesNPhysicsConfig;
+import de.devin.pipesnphysics.engine.FluidTankGeometry;
 import dev.ryanhcode.sable.api.physics.mass.MassTracker;
 import dev.ryanhcode.sable.companion.math.Pose3dc;
 import dev.ryanhcode.sable.sublevel.ServerSubLevel;
@@ -18,13 +20,12 @@ public class SablePhysicsCompat {
 
     private static final Map<String, Double> lastAppliedMass = new HashMap<>();
 
-    public static void applyFluidWeight(ServerSubLevel subLevel, BlockPos controllerPos,
-                                        int width, int height, double fillFraction,
-                                        double massKg, double timeStep) {
+    public static void applyFluidWeight(ServerSubLevel subLevel, FluidTankBlockEntity controller,
+                                        double fillFraction, double massKg, double timeStep) {
         if (massKg <= 0) return;
 
         if (PipesNPhysicsConfig.EXPERIMENTAL_TANK_COG.get()) {
-            applyViaMassTracker(subLevel, controllerPos, fillFraction, massKg);
+            applyViaMassTracker(subLevel, controller, fillFraction, massKg);
         } else {
             applyViaForce(subLevel, massKg);
         }
@@ -42,12 +43,14 @@ public class SablePhysicsCompat {
 
     private static final Map<String, Vec3> lastAppliedOffset = new HashMap<>();
 
-    private static void applyViaMassTracker(ServerSubLevel subLevel, BlockPos controllerPos, double fillFraction, double massKg) {
+    private static void applyViaMassTracker(ServerSubLevel subLevel, FluidTankBlockEntity controller,
+                                            double fillFraction, double massKg) {
         MassTracker tracker = subLevel.getSelfMassTracker();
         if (tracker == null) return;
 
+        BlockPos controllerPos = controller.getBlockPos();
         String key = subLevel.getUniqueId() + ":" + controllerPos.toShortString();
-        Vec3 offset = tiltAwareOffset(subLevel, fillFraction);
+        Vec3 offset = tiltAwareOffset(subLevel, controller, fillFraction);
 
         Double prevMass = lastAppliedMass.get(key);
         if (prevMass != null && Math.abs(prevMass - massKg) < 0.001) return;
@@ -86,7 +89,7 @@ public class SablePhysicsCompat {
             var level = subLevel.getLevel();
             BlockState state = level.getBlockState(controllerPos);
             tracker.addBlockMass(level, state, controllerPos, -prevMass,
-                    prevOffset != null ? prevOffset : tiltAwareOffset(subLevel, 0));
+                    prevOffset != null ? prevOffset : tiltAwareOffset(subLevel, null, 0));
         } catch (Exception e) {
             PipesNPhysics.LOGGER.warn("Failed to withdraw fluid tank mass at {}", controllerPos, e);
         }
@@ -98,10 +101,23 @@ public class SablePhysicsCompat {
         lastAppliedOffset.clear();
     }
 
-    private static Vec3 tiltAwareOffset(ServerSubLevel subLevel, double fillFraction) {
-        double cx = 0.5;
-        double cy = fillFraction / 2.0;
-        double cz = 0.5;
+    private static Vec3 tiltAwareOffset(ServerSubLevel subLevel, FluidTankBlockEntity controller,
+                                      double fillFraction) {
+        double cx;
+        double cy;
+        double cz;
+        if (controller != null) {
+            FluidTankGeometry.RenderInterior interior = FluidTankGeometry.renderInterior(controller, 0f);
+            FluidTankGeometry.LocalExtents ext = FluidTankGeometry.localExtents(controller);
+            cx = interior.centerX() / ext.x();
+            float fluidTop = interior.yMin() + (float) (fillFraction * interior.fillSpanY());
+            cy = (interior.yMin() + fluidTop) * 0.5 / ext.y();
+            cz = interior.centerZ() / ext.z();
+        } else {
+            cx = 0.5;
+            cy = fillFraction / 2.0;
+            cz = 0.5;
+        }
 
         Pose3dc pose = subLevel.logicalPose();
         if (pose == null) return new Vec3(cx, cy, cz);

--- a/src/main/java/de/devin/pipesnphysics/engine/BoundaryColumn.java
+++ b/src/main/java/de/devin/pipesnphysics/engine/BoundaryColumn.java
@@ -7,7 +7,6 @@ import com.simibubi.create.content.fluids.tank.FluidTankBlockEntity;
 import com.simibubi.create.foundation.mixin.accessor.FlowingFluidAccessor;
 import de.devin.pipesnphysics.PipesNPhysicsConfig;
 import de.devin.pipesnphysics.compat.SableCompat;
-import de.devin.pipesnphysics.mixin.FluidTankAccessor;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.Level;
@@ -162,13 +161,12 @@ public final class BoundaryColumn {
             FluidTankBlockEntity controller = tankBe.getControllerBE();
             if (controller == null) return null; // multiblock mid-assembly or controller unloaded
             FluidTank inventory = controller.getTankInventory();
-            int height = ((FluidTankAccessor) (Object) controller).pipesnphysics$getHeight();
-            int width = ((FluidTankAccessor) (Object) controller).pipesnphysics$getWidth();
+            int height = FluidTankGeometry.columnHeightBlocks(controller);
             BlockPos controllerPos = controller.getBlockPos();
             FluidStack fluid = inventory.getFluid();
             return new BoundaryColumn(
                     controllerPos, pos,
-                    SableCompat.getColumnBaseY(level, controllerPos, width, height),
+                    FluidTankGeometry.columnBaseY(level, controllerPos, controller),
                     height, inventory.getCapacity(), fluid.copy(), fluid.getAmount(), null, false, true,
                     SableCompat.getUpProjectionY(level, controllerPos));
         }

--- a/src/main/java/de/devin/pipesnphysics/engine/FluidTankGeometry.java
+++ b/src/main/java/de/devin/pipesnphysics/engine/FluidTankGeometry.java
@@ -18,6 +18,31 @@ import java.util.List;
 public final class FluidTankGeometry {
     private FluidTankGeometry() {}
 
+    /** End-cap thickness along the tank/vessel length axis (matches Create). */
+    public static final float CAP = 1 / 4f;
+    /** Puddle lip above the interior floor along the length axis. */
+    public static final float PUDDLE = 1 / 16f;
+    /** Glass hull wall thickness on cross-section axes. */
+    public static final float HULL = 1 / 16f + 1 / 128f;
+
+    /** Multiblock extent along each local axis from the controller origin, in blocks. */
+    public record LocalExtents(int x, int y, int z) {}
+
+    /**
+     * Inset fluid-interior box in controller-local block coordinates, plus the span along local Y
+     * used to map fill fraction to height when the tank is upright.
+     */
+    public record RenderInterior(
+            float xMin, float xMax,
+            float yMin, float yMax,
+            float zMin, float zMax,
+            float fillSpanY
+    ) {
+        public float centerX() { return (xMin + xMax) * 0.5f; }
+        public float centerY() { return (yMin + yMax) * 0.5f; }
+        public float centerZ() { return (zMin + zMax) * 0.5f; }
+    }
+
     public static boolean isHorizontal(FluidTankBlockEntity controller) {
         return controller.getMainConnectionAxis() != Direction.Axis.Y;
     }
@@ -68,6 +93,57 @@ public final class FluidTankGeometry {
         int width = ((FluidTankAccessor) (Object) controller).pipesnphysics$getWidth();
         int length = ((FluidTankAccessor) (Object) controller).pipesnphysics$getHeight();
         return isHorizontal(controller) ? width : length;
+    }
+
+    public static LocalExtents localExtents(FluidTankBlockEntity controller) {
+        int width = ((FluidTankAccessor) (Object) controller).pipesnphysics$getWidth();
+        int length = ((FluidTankAccessor) (Object) controller).pipesnphysics$getHeight();
+        Direction.Axis axis = controller.getMainConnectionAxis();
+        if (axis == Direction.Axis.Y) return new LocalExtents(width, length, width);
+        if (axis == Direction.Axis.X) return new LocalExtents(length, width, width);
+        return new LocalExtents(width, width, length);
+    }
+
+    /**
+     * Fluid-interior bounds for tilted rendering and center-of-mass offsets. Caps sit on the
+     * length axis (world Y for vertical tanks, X/Z for horizontal fluid vessels); hull walls sit
+     * on the cross-section axes.
+     */
+    public static RenderInterior renderInterior(FluidTankBlockEntity controller, float inset) {
+        int width = ((FluidTankAccessor) (Object) controller).pipesnphysics$getWidth();
+        int length = ((FluidTankAccessor) (Object) controller).pipesnphysics$getHeight();
+        Direction.Axis axis = controller.getMainConnectionAxis();
+
+        float yMin = HULL + inset;
+        float yMax = HULL + width - 2 * HULL - inset;
+        float hullSpanY = yMax - yMin;
+
+        if (axis == Direction.Axis.Y) {
+            float xMin = HULL + inset;
+            float xMax = HULL + width - 2 * HULL - inset;
+            float zMin = HULL + inset;
+            float zMax = HULL + width - 2 * HULL - inset;
+            float fillSpanY = length - 2 * CAP - PUDDLE;
+            float spanYMin = CAP + inset;
+            float spanYMax = CAP + PUDDLE + fillSpanY - inset;
+            return new RenderInterior(xMin, xMax, spanYMin, spanYMax, zMin, zMax, fillSpanY);
+        }
+
+        float lengthSpan = length - 2 * CAP - PUDDLE;
+        float xMin = HULL + inset;
+        float xMax = HULL + width - 2 * HULL - inset;
+        float zMin = HULL + inset;
+        float zMax = HULL + width - 2 * HULL - inset;
+
+        if (axis == Direction.Axis.X) {
+            float spanXMin = CAP + inset;
+            float spanXMax = CAP + PUDDLE + lengthSpan - inset;
+            return new RenderInterior(spanXMin, spanXMax, yMin, yMax, zMin, zMax, hullSpanY);
+        }
+
+        float spanZMin = CAP + inset;
+        float spanZMax = CAP + PUDDLE + lengthSpan - inset;
+        return new RenderInterior(xMin, xMax, yMin, yMax, spanZMin, spanZMax, hullSpanY);
     }
 
     /** World-Y of the bottom of the hydraulic column used by the solver. */

--- a/src/main/java/de/devin/pipesnphysics/engine/FluidTankGeometry.java
+++ b/src/main/java/de/devin/pipesnphysics/engine/FluidTankGeometry.java
@@ -1,0 +1,89 @@
+package de.devin.pipesnphysics.engine;
+
+import com.simibubi.create.content.fluids.tank.FluidTankBlockEntity;
+import de.devin.pipesnphysics.compat.SableCompat;
+import de.devin.pipesnphysics.mixin.FluidTankAccessor;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Multiblock footprint and hydraulic column geometry for Create fluid tanks and Create: Connected
+ * horizontal fluid vessels. Vessels reuse {@link FluidTankBlockEntity}'s {@code width}/{@code height}
+ * fields but lay out along {@link FluidTankBlockEntity#getMainConnectionAxis()} instead of world-up.
+ */
+public final class FluidTankGeometry {
+    private FluidTankGeometry() {}
+
+    public static boolean isHorizontal(FluidTankBlockEntity controller) {
+        return controller.getMainConnectionAxis() != Direction.Axis.Y;
+    }
+
+    /** Every block cell in a multiblock tank or fluid vessel. */
+    public static List<BlockPos> footprint(FluidTankBlockEntity controller) {
+        int width = ((FluidTankAccessor) (Object) controller).pipesnphysics$getWidth();
+        int length = ((FluidTankAccessor) (Object) controller).pipesnphysics$getHeight();
+        BlockPos base = controller.getBlockPos();
+        Direction.Axis axis = controller.getMainConnectionAxis();
+
+        List<BlockPos> blocks = new ArrayList<>(width * width * length);
+        if (axis == Direction.Axis.Y) {
+            for (int dx = 0; dx < width; dx++) {
+                for (int dy = 0; dy < length; dy++) {
+                    for (int dz = 0; dz < width; dz++) {
+                        blocks.add(base.offset(dx, dy, dz));
+                    }
+                }
+            }
+            return blocks;
+        }
+
+        for (int y = 0; y < width; y++) {
+            for (int len = 0; len < length; len++) {
+                for (int w = 0; w < width; w++) {
+                    blocks.add(base.offset(
+                            axis == Direction.Axis.X ? len : w,
+                            y,
+                            axis == Direction.Axis.Z ? len : w));
+                }
+            }
+        }
+        return blocks;
+    }
+
+    public static List<BlockPos> footprint(Level level, BlockPos pos) {
+        if (!(level.getBlockEntity(pos) instanceof FluidTankBlockEntity tank)) return List.of(pos);
+        FluidTankBlockEntity controller = tank.getControllerBE();
+        return controller != null ? footprint(controller) : List.of(pos);
+    }
+
+    /**
+     * Vertical extent in blocks along which fill rises for head equalization. For a vertical tank this
+     * is its height; for a horizontal fluid vessel it is the cross-section height ({@code width}).
+     */
+    public static int columnHeightBlocks(FluidTankBlockEntity controller) {
+        int width = ((FluidTankAccessor) (Object) controller).pipesnphysics$getWidth();
+        int length = ((FluidTankAccessor) (Object) controller).pipesnphysics$getHeight();
+        return isHorizontal(controller) ? width : length;
+    }
+
+    /** World-Y of the bottom of the hydraulic column used by the solver. */
+    public static double columnBaseY(Level level, BlockPos controllerPos, FluidTankBlockEntity controller) {
+        int width = ((FluidTankAccessor) (Object) controller).pipesnphysics$getWidth();
+        int length = ((FluidTankAccessor) (Object) controller).pipesnphysics$getHeight();
+        int vertical = columnHeightBlocks(controller);
+        Direction.Axis axis = controller.getMainConnectionAxis();
+
+        if (axis == Direction.Axis.Y) {
+            return SableCompat.getColumnBaseY(level, controllerPos, width, vertical);
+        }
+
+        double halfX = axis == Direction.Axis.X ? length / 2.0 : width / 2.0;
+        double halfY = vertical / 2.0;
+        double halfZ = axis == Direction.Axis.Z ? length / 2.0 : width / 2.0;
+        return SableCompat.getColumnBaseYAtCenter(level, controllerPos, halfX, halfY, halfZ, vertical);
+    }
+}

--- a/src/main/java/de/devin/pipesnphysics/engine/GraphBuilder.java
+++ b/src/main/java/de/devin/pipesnphysics/engine/GraphBuilder.java
@@ -4,8 +4,6 @@ import com.simibubi.create.content.fluids.FluidPropagator;
 import com.simibubi.create.content.fluids.FluidTransportBehaviour;
 import com.simibubi.create.content.fluids.pipes.VanillaFluidTargets;
 import com.simibubi.create.content.fluids.pump.PumpBlock;
-import com.simibubi.create.content.fluids.tank.FluidTankBlockEntity;
-import de.devin.pipesnphysics.mixin.FluidTankAccessor;
 import de.devin.pipesnphysics.compat.SableCompat;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -331,24 +329,7 @@ public final class GraphBuilder {
 
     /** The block(s) a handler occupies: a multiblock tank's whole footprint, or just the single block. */
     private static List<BlockPos> handlerExtent(Level level, BlockPos pos) {
-        if (level.getBlockEntity(pos) instanceof FluidTankBlockEntity tank) {
-            FluidTankBlockEntity controller = tank.getControllerBE();
-            if (controller != null) {
-                int width = ((FluidTankAccessor) (Object) controller).pipesnphysics$getWidth();
-                int height = ((FluidTankAccessor) (Object) controller).pipesnphysics$getHeight();
-                BlockPos base = controller.getBlockPos();
-                List<BlockPos> blocks = new ArrayList<>(width * width * height);
-                for (int dx = 0; dx < width; dx++) {
-                    for (int dy = 0; dy < height; dy++) {
-                        for (int dz = 0; dz < width; dz++) {
-                            blocks.add(base.offset(dx, dy, dz));
-                        }
-                    }
-                }
-                return blocks;
-            }
-        }
-        return List.of(pos);
+        return FluidTankGeometry.footprint(level, pos);
     }
 
     /**

--- a/src/main/java/de/devin/pipesnphysics/handler/NetworkEditHandler.java
+++ b/src/main/java/de/devin/pipesnphysics/handler/NetworkEditHandler.java
@@ -4,8 +4,8 @@ import com.simibubi.create.content.fluids.FluidPropagator;
 import com.simibubi.create.content.fluids.tank.FluidTankBlockEntity;
 import de.devin.pipesnphysics.PipesNPhysicsConfig;
 import de.devin.pipesnphysics.engine.EngineTickHandler;
+import de.devin.pipesnphysics.engine.FluidTankGeometry;
 import de.devin.pipesnphysics.engine.OpenEndPipes;
-import de.devin.pipesnphysics.mixin.FluidTankAccessor;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.Level;
@@ -80,18 +80,10 @@ public final class NetworkEditHandler {
         if (!(level.getBlockEntity(pos) instanceof FluidTankBlockEntity tank)) return;
         FluidTankBlockEntity controller = tank.getControllerBE();
         if (controller == null) return;
-        int width = ((FluidTankAccessor) (Object) controller).pipesnphysics$getWidth();
-        int height = ((FluidTankAccessor) (Object) controller).pipesnphysics$getHeight();
-        BlockPos base = controller.getBlockPos();
-        for (int dx = 0; dx < width; dx++) {
-            for (int dy = 0; dy < height; dy++) {
-                for (int dz = 0; dz < width; dz++) {
-                    BlockPos cell = base.offset(dx, dy, dz);
-                    for (Direction dir : Direction.values()) {
-                        BlockPos neighbor = cell.relative(dir);
-                        if (isPipe(level, neighbor)) EngineTickHandler.markChanged(level, neighbor);
-                    }
-                }
+        for (BlockPos cell : FluidTankGeometry.footprint(controller)) {
+            for (Direction dir : Direction.values()) {
+                BlockPos neighbor = cell.relative(dir);
+                if (isPipe(level, neighbor)) EngineTickHandler.markChanged(level, neighbor);
             }
         }
     }

--- a/src/main/java/de/devin/pipesnphysics/mixin/FluidTankMassMixin.java
+++ b/src/main/java/de/devin/pipesnphysics/mixin/FluidTankMassMixin.java
@@ -41,12 +41,8 @@ public class FluidTankMassMixin implements BlockEntitySubLevelActor {
         double fillFraction = TankMassFormulas.fillFraction(
                 fluidAmount, capacity);
 
-        int width = ((FluidTankAccessor) self).pipesnphysics$getWidth();
-        int height = ((FluidTankAccessor) self).pipesnphysics$getHeight();
-
         SablePhysicsCompat.applyFluidWeight(
-                subLevel, self.getBlockPos(), width, height, fillFraction,
-                massKg, timeStep
+                subLevel, self, fillFraction, massKg, timeStep
         );
     }
 }

--- a/src/main/java/de/devin/pipesnphysics/mixin/FluidTankRendererMixin.java
+++ b/src/main/java/de/devin/pipesnphysics/mixin/FluidTankRendererMixin.java
@@ -11,6 +11,7 @@ import de.devin.pipesnphysics.client.FluidRenderData.GridDims;
 import de.devin.pipesnphysics.client.FluidRenderData.SurfacePlane;
 import de.devin.pipesnphysics.client.FluidRenderData.TankBounds;
 import de.devin.pipesnphysics.PipesNPhysicsConfig;
+import de.devin.pipesnphysics.engine.FluidTankGeometry;
 import dev.ryanhcode.sable.companion.ClientSubLevelAccess;
 import dev.ryanhcode.sable.companion.SableCompanion;
 import dev.ryanhcode.sable.companion.math.Pose3dc;
@@ -46,9 +47,6 @@ public class FluidTankRendererMixin {
 
     // --- Constants ---
     @Unique private static final float INSET = 0.003f;
-    @Unique private static final float CAP_HEIGHT = 1 / 4f;
-    @Unique private static final float HULL_WIDTH = 1 / 16f + 1 / 128f;
-    @Unique private static final float PUDDLE_HEIGHT = 1 / 16f;
 
     /** Box edge pairs for plane-box intersection. */
     @Unique private static final int[][] BOX_EDGES = {
@@ -149,9 +147,8 @@ public class FluidTankRendererMixin {
         FluidStack fluidStack = tank.getFluid();
         if (fluidStack.isEmpty()) return;
 
-        int width = acc.pipesnphysics$getWidth();
-        int height = acc.pipesnphysics$getHeight();
-        float totalHeight = height - 2 * CAP_HEIGHT - PUDDLE_HEIGHT;
+        FluidTankGeometry.RenderInterior interior = FluidTankGeometry.renderInterior(be, INSET);
+        float totalHeight = interior.fillSpanY();
 
         // Read actual fill fraction directly from the tank inventory.
         // Create's LerpedFloat may not tick on Sable sub-levels, causing laggy animation.
@@ -180,11 +177,11 @@ public class FluidTankRendererMixin {
         float clampedLevel = Mth.clamp(level * totalHeight, 0, totalHeight);
 
         // --- Tank bounds (inset to prevent z-fighting with tank glass) ---
-        float xMin = HULL_WIDTH + INSET, xMax = HULL_WIDTH + width - 2 * HULL_WIDTH - INSET;
-        float yMin = CAP_HEIGHT + INSET, yMax = CAP_HEIGHT + PUDDLE_HEIGHT + totalHeight - INSET;
-        float zMin = HULL_WIDTH + INSET, zMax = HULL_WIDTH + width - 2 * HULL_WIDTH - INSET;
+        float xMin = interior.xMin(), xMax = interior.xMax();
+        float yMin = interior.yMin(), yMax = interior.yMax();
+        float zMin = interior.zMin(), zMax = interior.zMax();
         float[] mins = {xMin, yMin, zMin}, maxs = {xMax, yMax, zMax};
-        float cx = (xMin + xMax) / 2f, cy = (yMin + yMax) / 2f, cz = (zMin + zMax) / 2f;
+        float cx = interior.centerX(), cy = interior.centerY(), cz = interior.centerZ();
         TankBounds bounds = new TankBounds(mins, maxs, new float[]{cx, cy, cz});
 
         // --- Surface plane: find where the fluid surface cuts through the tank box ---

--- a/src/main/resources/data/pipesnphysics/tags/block/is_reservoir.json
+++ b/src/main/resources/data/pipesnphysics/tags/block/is_reservoir.json
@@ -1,4 +1,13 @@
 {
   "replace": false,
-  "values": []
+  "values": [
+    {
+      "id": "create_connected:fluid_vessel",
+      "required": false
+    },
+    {
+      "id": "create_connected:creative_fluid_vessel",
+      "required": false
+    }
+  ]
 }

--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -49,3 +49,10 @@ type = "optional"
 versionRange = "[1.2.0,)"
 ordering = "AFTER"
 side = "BOTH"
+
+[[dependencies.${mod_id}]]
+modId = "create_connected"
+type = "optional"
+versionRange = "[1.0.0,)"
+ordering = "NONE"
+side = "BOTH"


### PR DESCRIPTION
- Replaced direct accessor calls with methods from FluidTankGeometry for height and base Y calculations in CreatePipeRendering and other classes.
- Introduced new method getColumnBaseYAtCenter in SableCompat and SableCompatProvider to handle tanks with non-centered geometric layouts.
- Updated footprint calculation in GraphBuilder to utilize FluidTankGeometry.
- Added fluid vessel types to is_reservoir tag for better fluid handling.
- Updated dependencies in neoforge.mods.toml for create_connected mod.

<!-- Thanks for contributing! Keep this short — a few honest lines beat a wall of boilerplate. -->

## What & why

<!-- What does this change do, and what problem does it solve? Link any related issue: Closes #123 -->

## How it was tested

<!-- Tick what applies. GameTests run automatically in CI on this PR. -->

- [ ] `./gradlew test` (pure-Java solver JUnit tests) pass
- [ ] `./gradlew runGameTestServer` (Create GameTests) pass
- [ ] Verified in-game (render / world-side behaviour that GameTests can't cover)

## Notes for reviewers

<!-- Anything non-obvious: a design trade-off, a known gap, a follow-up, or an area that needs a close look. -->
